### PR TITLE
Add doc-comment to test README's examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ readme = "README.md"
 cfg-if = "0.1.10"
 libc = "0.2.74"
 
+[dev-dependencies]
+doc-comment = "0.3"
+
 [target.'cfg(windows)'.dependencies]
 # Patched version of wepoll that can be notified by PostQueuedCompletionStatus.
 wepoll-sys-stjepang = "1.0.6"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Only one thread can be waiting for I/O events at a time.
 
 ## Examples
 
-```rust
+```rust,no_run
 use polling::{Event, Poller};
 use std::net::TcpListener;
 
@@ -54,6 +54,7 @@ loop {
         }
     }
 }
+std::io::Result::Ok(())
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 use std::fmt;
 use std::io;
 use std::sync::Mutex;


### PR DESCRIPTION
I discovered this crate through a tweet and liked it. Just in case you didn't know about `doc-comment`, it's pretty convenient to keep your README.md file's examples up-to-date.

Good job on this crate anyway!