### PR TITLE
Event::none creates an event that is not readable or writable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,8 @@ impl Event {
     pub fn none(key: usize) -> Event {
         Event {
             key,
-            readable: true,
-            writable: true,
+            readable: false,
+            writable: false,
         }
     }
 }


### PR DESCRIPTION
Quick fix for probable copy-paste.