### PR TITLE
Add event ports for illumos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ https://docs.rs/polling)
 Portable interface to epoll, kqueue, and wepoll.
 
 Supported platforms:
-- [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android, illumos
+- [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android
 - [kqueue](https://en.wikipedia.org/wiki/Kqueue): macOS, iOS, FreeBSD, NetBSD, OpenBSD,
   DragonFly BSD
+- [event ports](https://illumos.org/man/port_create): illumos, Solaris
 - [wepoll](https://github.com/piscisaureus/wepoll): Windows
 
 Polling is done in oneshot mode, which means interest in I/O events needs to be reset after

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
-//! Portable interface to epoll, kqueue, and wepoll.
+//! Portable interface to epoll, kqueue, event ports, and wepoll.
 //!
 //! Supported platforms:
-//! - [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android, illumos
+//! - [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android
 //! - [kqueue](https://en.wikipedia.org/wiki/Kqueue): macOS, iOS, FreeBSD, NetBSD, OpenBSD,
 //!   DragonFly BSD
+//! - [event ports](https://illumos.org/man/port_create): illumos, Solaris
 //! - [wepoll](https://github.com/piscisaureus/wepoll): Windows
 //!
 //! Polling is done in oneshot mode, which means interest in I/O events needs to be reset after

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,15 @@ macro_rules! syscall {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "android", target_os = "illumos"))] {
+    if #[cfg(any(target_os = "linux", target_os = "android"))] {
         mod epoll;
         use epoll as sys;
+    } else if #[cfg(any(
+        target_os = "illumos",
+        target_os = "solaris",
+    ))] {
+        mod port;
+        use port as sys;
     } else if #[cfg(any(
         target_os = "macos",
         target_os = "ios",

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,18 +1,18 @@
 //! Bindings to event port (illumos, Solaris).
 
-use std::ptr;
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::io::{self, Read, Write};
-use std::time::Duration;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
+use std::ptr;
+use std::time::Duration;
 use std::usize;
 
 use crate::Event;
 
-/// Interface to epoll.
+/// Interface to event ports.
 #[derive(Debug)]
 pub struct Poller {
-    /// File descriptor for the epoll instance.
+    /// File descriptor for the port instance.
     port_fd: RawFd,
     /// Read side of a pipe for consuming notifications.
     read_stream: UnixStream,
@@ -39,7 +39,11 @@ impl Poller {
         read_stream.set_nonblocking(true)?;
         write_stream.set_nonblocking(true)?;
 
-        let poller = Poller { port_fd, read_stream, write_stream };
+        let poller = Poller {
+            port_fd,
+            read_stream,
+            write_stream,
+        };
         poller.interest(
             poller.read_stream.as_raw_fd(),
             Event {


### PR DESCRIPTION
This adds the use of the preferred evented I/O mechanism on illumos/solaris. This also means `polling` should work on a a real Solaris box (as it doesn't have eventfd or epoll) although I have not tested in such an environment. 

I ran the test suite and verified everything passed. I also ran a modified version of a toy [tcp-proxy](https://github.com/papertigers/proxy-rs) that uses async-std to verify bits were able to flow in both directions with the included patch.

Note I have only tested with the "solaris" version of rustc on illumos.  I will update this PR shortly with testing notes from a rust nightly build that actually uses the illumos rustc target.

Also worth noting I chose to reuse the pipe method from kqueue instead of eventfd even though illumos supports it, so that a real Solaris build is able to take advantage of this crate.

```
root - rustdev ~/src/polling (git:illumos) # cargo test
   Compiling polling v0.1.0 (/root/src/polling)
    Finished test [unoptimized + debuginfo] target(s) in 1.14s
     Running target/debug/deps/polling-fbc74159dd2c3d72

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests polling

running 10 tests
test src/lib.rs - Poller::interest (line 229) ... ok
test src/lib.rs - Poller::interest (line 240) ... ok
test src/lib.rs - Poller::interest (line 262) ... ok
test src/lib.rs - Poller::interest (line 251) ... ok
test src/lib.rs -  (line 16) ... ok
test src/lib.rs - Poller::new (line 168) ... ok
test src/lib.rs - Poller::notify (line 350) ... ok
test src/lib.rs - Poller::remove (line 285) ... ok
test src/lib.rs - Poller::insert (line 189) ... ok
test src/lib.rs - Poller::wait (line 318) ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```