### PR TITLE
Fix compilation on x32

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -157,7 +157,7 @@ impl Poller {
                 None => TS_ZERO,
                 Some(t) => libc::timespec {
                     tv_sec: t.as_secs() as libc::time_t,
-                    tv_nsec: t.subsec_nanos() as libc::c_long,
+                    tv_nsec: (t.subsec_nanos() as libc::c_long).into(),
                 },
             },
         };


### PR DESCRIPTION
Fix compilation on x86_64-unknown-linux-gnux32, where
libc's timespec's `tv_nsec` is [defined as `i64`]. See also
[this bug] bug for further discussion.

[defined as `i64`]: https://github.com/rust-lang/libc/blob/master/src/unix/mod.rs#L61
[this bug]: https://sourceware.org/bugzilla/show_bug.cgi?id=16437